### PR TITLE
Remember previous settings

### DIFF
--- a/src/components/SettingsScreen.jsx
+++ b/src/components/SettingsScreen.jsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { loadPreviousSettings, saveSettings } from "../utilities/settings";
 
 function SettingsScreen({ doneConfiguring }) {
   const [hasProgressiveBeam, setHasProgressiveBeam] = useState(false);
@@ -11,6 +12,21 @@ function SettingsScreen({ doneConfiguring }) {
   const [flashShiftHasUpgrades, setFlashShiftHasUpgrades] = useState(false);
   const [startWithPulseRadar, setStartWithPulseRadar] = useState(false);
   const [allMajorBossesHaveDna, setAllMajorBossesHaveDna] = useState(false);
+
+  useEffect(() => {
+    const previousSettings = loadPreviousSettings();
+
+    setHasProgressiveBeam(previousSettings.progressiveBeam ?? false);
+    setHasProgressiveCharge(previousSettings.progressiveCharge ?? false);
+    setHasProgressiveBomb(previousSettings.progressiveBomb ?? false);
+    setHasProgressiveMissile(previousSettings.progressiveMissile ?? false);
+    setHasProgressiveSpin(previousSettings.progressiveSpin ?? false);
+    setHasProgressiveSuit(previousSettings.progressiveSuit ?? false);
+    setSpeedBoosterHasUpgrades(previousSettings.speedBoosterHasUpgrades ?? false);
+    setFlashShiftHasUpgrades(previousSettings.flashShiftHasUpgrades ?? false);
+    setStartWithPulseRadar(previousSettings.startWithPulseRadar ?? false);
+    setAllMajorBossesHaveDna(previousSettings.allMajorBossesHaveDna ?? false);
+  }, []);
 
   return (
     <div className="container">
@@ -128,6 +144,7 @@ function SettingsScreen({ doneConfiguring }) {
                 allMajorBossesHaveDna: allMajorBossesHaveDna,
               };
 
+              saveSettings(settings);
               doneConfiguring(settings);
             }}
           >

--- a/src/utilities/settings.js
+++ b/src/utilities/settings.js
@@ -1,0 +1,22 @@
+const SettingsKey = "tracker.lastSettings";
+
+export function loadPreviousSettings() {
+  const settingsJson = localStorage.getItem(SettingsKey);
+
+  try {
+    const settings = JSON.parse(settingsJson ?? "{}");
+
+    return settings ?? {};
+  } catch (err) {
+    console.error("Error loading previous settings:", err);
+    return {};
+  }
+}
+
+export function saveSettings(settings) {
+  try {
+    localStorage.setItem(SettingsKey, JSON.stringify(settings));
+  } catch (err) {
+    console.error("Could not save settings to local storage:", err);
+  }
+}


### PR DESCRIPTION
The tracker remembers the "last used settings" and pre-fills the settings page with them the next time it's opened. Saves time when starting a new seed on the same preset.