### PR TITLE
Fix Vite build and bugs

### DIFF
--- a/src/components/MajorProgressiveItemCell.tsx
+++ b/src/components/MajorProgressiveItemCell.tsx
@@ -16,8 +16,8 @@ const MajorProgressiveItemCell = observer(({ itemState }: MajorProgressiveItemCe
 	useLocationHotkeys(mouseOver, itemState, hotkeysDisabled);
 
 	const incrementLocationState = useCallback((e: React.MouseEvent) => {
-		if (e.currentTarget !== e.target) {
-			return;
+		if (e.currentTarget === e.target) {
+			e.stopPropagation();
 		}
 
 		itemState.incrementLocation();
@@ -26,8 +26,8 @@ const MajorProgressiveItemCell = observer(({ itemState }: MajorProgressiveItemCe
 	const decrementLocationState = useCallback((e: React.MouseEvent) => {
 		e.preventDefault();
 
-		if (e.currentTarget !== e.target) {
-			return;
+		if (e.currentTarget === e.target) {
+			e.stopPropagation();
 		}
 
 		itemState.decrementLocation();

--- a/src/store/BaseItemState.ts
+++ b/src/store/BaseItemState.ts
@@ -13,6 +13,11 @@ export abstract class BaseItemState {
 
 	@action
 	incrementLocation() {
+		if (this.startingLocation === locations.Starting) {
+			// Can't change location of starting items
+			return;
+		}
+
 		const index = locations.findIndex(l => l.name === this.location.name);
 		const newIndex = (index + 1) % locations.length;
 
@@ -21,6 +26,11 @@ export abstract class BaseItemState {
 
 	@action
 	decrementLocation() {
+		if (this.startingLocation === locations.Starting) {
+			// Can't change location of starting items
+			return;
+		}
+
 		const index = locations.findIndex(l => l.name === this.location.name);
 		const newIndex = index <= 0 ? (locations.length - 1) : (index - 1);
 
@@ -29,6 +39,11 @@ export abstract class BaseItemState {
 
 	@action
 	setLocationFromShortcut(shortcut: string) {
+		if (this.startingLocation === locations.Starting) {
+			// Can't change location of starting items
+			return;
+		}
+
 		this.location = locations.find(l => l.initial.toUpperCase() === shortcut.toUpperCase()) ?? locations.Unknown;
 	}
 }

--- a/src/store/SingleItemState.ts
+++ b/src/store/SingleItemState.ts
@@ -9,10 +9,18 @@ export class SingleItemState extends BaseItemState {
 
 	constructor(readonly item: SingleMajorItem, startingLocation: ResourceLocation = locations.Unknown) {
 		super(startingLocation);
+
+		if (startingLocation === locations.Starting) {
+			this.collected = true;
+		}
 	}
 
 	@action
 	toggleCollected() {
+		if (this.startingLocation === locations.Starting) {
+			return;
+		}
+
 		this.collected = !this.collected;
 	}
 

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -5,6 +5,11 @@ import eslint from "vite-plugin-eslint2";
 
 // https://vitejs.dev/config/
 export default defineConfig({
+	esbuild: {
+		supported: {
+			decorators: false,
+		},
+	},
 	plugins: [
 		eslint(),
 		react({


### PR DESCRIPTION
Fix the issue with Vite throwing an error when building production.

Also fixed a few interaction bugs:
- Clicking to change location of progressive items wasn't working
- "Automatic starting" items (e.g. Pulse Radar) could mistakenly have the location changed
- "Automatic starting" items did not start as collected (they should also not be able to be marked un-collected)